### PR TITLE
allow spaces in keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for trivialini
 
+## TODO
+
+* Allow whitespace in keys (Alexander Pankoff @ccntrq)
+
 ## 0.3.0.0 -- 2021-07-14
 
 * Breaking changes:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ bar = 42
 "42"
 ```
 
+## Contributors
+
+- Alexander Pankoff (@ccntrq)
+
 ## Author and License
 
 Copyright (c) 2021 Mirko Westermeier

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ answer = 42
 name = Boaty McBoatface
 ```
 
-There are two *sections* (inbetween `[` and `]`) defined, `something` and `something else`. These sections contain a dictionary of Strings each, the keys being something without whitespace, followed by `=` and anything else until end of the line.
+There are two *sections* (inbetween `[` and `]`) defined, `something` and `something else`. These sections contain a dictionary of Strings each, the keys being some string followed by `=`, and anything else until end of the line as values.
 
 **trivialini** parses this data structure as an `Ini`, which is simply a map of maps of strings:
 

--- a/src/Trivialini/Parser.hs
+++ b/src/Trivialini/Parser.hs
@@ -3,6 +3,7 @@ module Trivialini.Parser ( readIni, parseIni ) where
 
 import Trivialini.Ini ( Ini )
 import Data.Char ( isSpace )
+import Data.List ( dropWhileEnd )
 import Data.Map ( fromList, Map )
 import Text.ParserCombinators.ReadP
     ( between, char, many, munch1, readP_to_S,
@@ -25,12 +26,7 @@ pair = do
     skipMany1 (char '\n')
     return (keyHead:keyRest, value)
   where
-    removeTrailingSpaces :: String -> String
-    removeTrailingSpaces = reverse . removeLeadingSpaces . reverse
-      where
-        removeLeadingSpaces [] = []
-        removeLeadingSpaces str@(x : xs) | isSpace x = removeLeadingSpaces xs
-                                         | otherwise = str
+    removeTrailingSpaces = dropWhileEnd isSpace
 
 section :: ReadP (String, Map String String)
 section = do

--- a/src/Trivialini/Parser.hs
+++ b/src/Trivialini/Parser.hs
@@ -2,6 +2,7 @@
 module Trivialini.Parser ( readIni, parseIni ) where
 
 import Trivialini.Ini ( Ini )
+import Data.Char ( isSpace )
 import Data.Map ( fromList, Map )
 import Text.ParserCombinators.ReadP
     ( between, char, many, munch1, readP_to_S,
@@ -15,14 +16,21 @@ sectionName = do
 
 pair :: ReadP (String, String)
 pair = do
-    keyHead <- satisfy (`notElem` "\n =[")
-    keyRest <- munch1 (`notElem` "\n =")
     skipSpaces
+    keyHead <- satisfy (`notElem` "\n =[")
+    keyRest <- removeTrailingSpaces <$> munch1 (`notElem` "\n=")
     char '='
     skipSpaces
     value <- munch1 (/= '\n')
     skipMany1 (char '\n')
     return (keyHead:keyRest, value)
+  where
+    removeTrailingSpaces :: String -> String
+    removeTrailingSpaces = reverse . removeLeadingSpaces . reverse
+      where
+        removeLeadingSpaces [] = []
+        removeLeadingSpaces str@(x : xs) | isSpace x = removeLeadingSpaces xs
+                                         | otherwise = str
 
 section :: ReadP (String, Map String String)
 section = do

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -12,13 +12,15 @@ exampleIni =
     \answer    =42\n\
     \[section name]\n\
     \baz    =      quux\n\
-    \not a key = nope\n\
-    \ignored= 17\n\
+    \ is a valid key = yes\n\
+    \seventeen= 17\n\
     \"
 
 expectedIni = fromList [
         ("xnorfzt", fromList [("foo", "bar"), ("answer", "42")]),
-        ("section name", fromList [("baz", "quux")])
+        ("section name", fromList [
+            ("baz", "quux"), ("is a valid key", "yes"), ("seventeen", "17")
+        ])
     ]
 
 iniParsingOK :: Bool

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -11,16 +11,12 @@ exampleIni =
     \\n\
     \answer    =42\n\
     \[section name]\n\
-    \baz    =      quux\n\
-    \ is a valid key = yes\n\
-    \seventeen= 17\n\
+    \ baz quux   =      quuux\n\
     \"
 
 expectedIni = fromList [
         ("xnorfzt", fromList [("foo", "bar"), ("answer", "42")]),
-        ("section name", fromList [
-            ("baz", "quux"), ("is a valid key", "yes"), ("seventeen", "17")
-        ])
+        ("section name", fromList [("baz quux", "quuux")])
     ]
 
 iniParsingOK :: Bool


### PR DESCRIPTION
ignores leading and trailing whitespace but allows for the use of spaces
inside of keys.

If you just want #5 to work, something like this could be used. This is probably not the most efficient solution as each key will have to be reversed twice.